### PR TITLE
feat!: disable swagger on production for security concern

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function bootstrap() {
     }),
   );
 
-  if (process.env.SWAGGER_ENABLED === 'true') {
+  if (process.env.NODE_ENV !== 'production' && process.env.SWAGGER_ENABLED === 'true') {
     initSwagger(app)
   }
 


### PR DESCRIPTION
I like the approach used in this Boilerplate, show us how much nestjs could achieve.

Interesting part is the transform pipes, where it is automically implements validation based on the DTO, `class-validator` is a real deal here.

Ok back to the topic, I think we shouldn't show the swagger in production, potentially harmful for production environment, enables it helps developers a lot, so we likely to only use it in development.

How about API documentation? I believe anyone would create separated project for that rather than using the swagger for external developers, code will be huge to separate important APIs and also not ideal.

So, I propose this changes based on that idea.